### PR TITLE
Fix train-dataset extraction path

### DIFF
--- a/Design_Tutorials/01-caffe_cats_vs_dogs/files/set_the_CATSvsDOGS_prj.py
+++ b/Design_Tutorials/01-caffe_cats_vs_dogs/files/set_the_CATSvsDOGS_prj.py
@@ -65,6 +65,12 @@ if (not os.path.exists(path_root + "/input")):
 ## unzip the kaggle_dogs_vs_cats.zip file
 os.system("unzip kaggle_dogs_vs_cats.zip -d" + path_root + "/input")
 
+## extract train.zip in input/train
+if (not os.path.exists(path_root + "/input/kaggle_dogs_vs_cats")):
+    os.mkdir(path_root + "/input/kaggle_dogs_vs_cats")
+
+os.system("unzip " + path_root + "/input/train.zip -d " + path_root + "/input/kaggle_dogs_vs_cats")
+
 # rename "/input/train" as "input/jpg"
 os.system("mv "    + path_root + "/input/kaggle_dogs_vs_cats/train " + path_root + "/input/jpg")
 os.system("rm -r " + path_root + "/input/kaggle_dogs_vs_cats")


### PR DESCRIPTION
I encountered an error while executing the set_the_CATSvsDOGS_prj.py script after placing the kaggle-cats-vs-dogs.zip file inside the files directory.

The following error appears: 
`(vitis-ai-caffe) Vitis-AI /workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files > python set_the_CATSvsDOGS_prj.py -i $ML_DIR
Archive:  kaggle_dogs_vs_cats.zip
  inflating: /workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/sampleSubmission.csv  
  inflating: /workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/test1.zip  
  inflating: /workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/train.zip  
mv: cannot stat '/workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/kaggle_dogs_vs_cats/train': No such file or directory
rm: cannot remove '/workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/kaggle_dogs_vs_cats': No such file or directory
Traceback (most recent call last):
  File "set_the_CATSvsDOGS_prj.py", line 79, in <module>
    os.mkdir(path_root + "/input/jpg/cats")
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/tutorials/VAI-Caffe-ML-CATSvsDOGS/files/input/jpg/cats'`

I have added few lines to extract the train.zip in the /input/kaggle_dogs_vs_cats/train directory.

