### PR TITLE
Solution Issue importing MNIST dataset

### DIFF
--- a/Design_Tutorials/09-mnist_pyt/files/train.py
+++ b/Design_Tutorials/09-mnist_pyt/files/train.py
@@ -38,10 +38,10 @@ DIVIDER = '-----------------------------------------'
 
 
 torchvision.datasets.MNIST.resources = [
-    ('https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz', 'f68b3c2dcbeaaa9fbdd348bbdeb94873'),
-    ('https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz', 'd53e105ee54ea40749a09fcbcd1e9432'),
-    ('https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz', '9fb629c4189551a2d022fa330f9573f3'),
-    ('https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz', 'ec29112dd5afa0611ce80d1b7f02629c')
+    ('train-images-idx3-ubyte.gz', 'f68b3c2dcbeaaa9fbdd348bbdeb94873'),
+    ('train-labels-idx1-ubyte.gz', 'd53e105ee54ea40749a09fcbcd1e9432'),
+    ('t10k-images-idx3-ubyte.gz', '9fb629c4189551a2d022fa330f9573f3'),
+    ('t10k-labels-idx1-ubyte.gz', 'ec29112dd5afa0611ce80d1b7f02629c')
 ]
 
 


### PR DESCRIPTION
torchvision.datasets.MNIST would already make the url of the download  http://yann.lecun.com/exdb/mnist/ + "{resources}". This would result in the URL becoming
 "http://yann.lecun.com/exdb/mnist/https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz", which gives a issue.